### PR TITLE
Development

### DIFF
--- a/web/src/main/java/de/betterform/agent/web/WebUtil.java
+++ b/web/src/main/java/de/betterform/agent/web/WebUtil.java
@@ -272,8 +272,10 @@ public class WebUtil {
         }
 
         String requestPath = "";
+        URL url=null;
+        String plainPath ="";
         try {
-            URL url = new URL(requestURL);
+            url = new URL(requestURL);
             requestPath = url.getPath();
         } catch (MalformedURLException e) {
             e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
@@ -283,17 +285,23 @@ public class WebUtil {
             processor.setContextParam(WebProcessor.REQUEST_PATH, requestPath);
 
             //adding filename of requested doc to context
-            String fileName = requestPath.substring(requestPath.lastIndexOf('/')+1,requestPath.length());
+            String fileName = requestPath.substring(requestPath.lastIndexOf('/')+1,requestPath.length());//FILENAME xforms
             processor.setContextParam(FILENAME, fileName);
 
-            //adding plainPath which is the part between contextroot and filename e.g. '/forms' for a requestPath of '/betterform/forms/Status.xhtml'
-            String plainPath = requestPath.substring(contextRoot.length()+1,requestPath.length() - fileName.length());
-            processor.setContextParam(PLAIN_PATH, plainPath);
+            if(requestURL.contains(contextRoot)){ //case1: contextRoot is a part of the URL
+	            //adding plainPath which is the part between contextroot and filename e.g. '/forms' for a requestPath of '/betterform/forms/Status.xhtml'
+	            plainPath = requestPath.substring(contextRoot.length()+1,requestPath.length() - fileName.length());
+	            processor.setContextParam(PLAIN_PATH, plainPath);
+            }
+            else{//case2: contextRoot is not a part of the URL
+            	String[] urlParts=requestURL.split("/");
+            	plainPath=urlParts[urlParts.length-2];
+            }
 
             //adding contextPath - requestPath without the filename
             processor.setContextParam(CONTEXT_PATH,contextRoot+"/"+plainPath);
+         }
 
-        }
 
         //adding session id to context
         processor.setContextParam(HTTP_SESSION_ID, httpSession.getId());

--- a/web/src/main/java/de/betterform/agent/web/WebUtil.java
+++ b/web/src/main/java/de/betterform/agent/web/WebUtil.java
@@ -293,7 +293,7 @@ public class WebUtil {
 	            plainPath = requestPath.substring(contextRoot.length()+1,requestPath.length() - fileName.length());
 	            processor.setContextParam(PLAIN_PATH, plainPath);
             }
-            else{//case2: contextRoot is not a part of the URL
+            else{//case2: contextRoot is not a part of the URL take the part previous the filename.
             	String[] urlParts=requestURL.split("/");
             	plainPath=urlParts[urlParts.length-2];
             }


### PR DESCRIPTION
I have developed the case for the context_root because before it was simply assumed that it was part of the URL, but apparently the client side could define it indipendently defining the constant ALTERNATIVE_ROOT so it was wrong in the code the way to retrieve the plainPath that was based on the wrong assumption (context_root contained in URL) so I have separate two cases one (IF clause) when the context_root is contained in the URL with the old substring (in this case is correct) and the other one (ELSE case) doing a simple parse of the string URL and taking the part before the file name (maybe we need to modify this spart but I have tried to ask clarification in the forum about plainPath when the context_root is not in the URL...but no good answer so I assumed that it was just the previous part before the filename).

thank you
I hope that my work will be useful for you

Daniele Ippoliti
