### PR TITLE
SaxonXPathExpressionSerializer prefix Bugfix

### DIFF
--- a/core/src/main/java/de/betterform/xml/xpath/impl/saxon/SaxonXPathExpressionSerializer.java
+++ b/core/src/main/java/de/betterform/xml/xpath/impl/saxon/SaxonXPathExpressionSerializer.java
@@ -67,6 +67,17 @@ public class SaxonXPathExpressionSerializer {
               NameTest nt = (NameTest) nodeTest;
               NamePool namePool = nt.getNamePool();
               String localName = namePool.getLocalName(nt.getFingerprint());
+              String prefix = namePool.getPrefix(nt.getFingerprint());
+              String uri = namePool.getURI(nt.getFingerprint());
+              
+              localName = (uri != null && !uri.trim().isEmpty())
+            		  	? ("{" + uri +"}" + localName)
+            		  	: localName;
+              
+              localName = (prefix != null && ! prefix.trim().isEmpty()) 
+            		  		  ? (prefix + ":"+localName) 
+            				  : localName;
+              
               result.append(fixPreFixes(localName, reversePrefixMapping));
             } else {
               result.append(fixPreFixes(nodeTest.toString(), reversePrefixMapping));

--- a/core/src/test/java/de/betterform/xml/xpath/XPathReferenceFinderTest.java
+++ b/core/src/test/java/de/betterform/xml/xpath/XPathReferenceFinderTest.java
@@ -4,13 +4,15 @@
  */
 package de.betterform.xml.xpath;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import junit.framework.TestCase;
 import de.betterform.xml.xforms.Container;
 import de.betterform.xml.xforms.xpath.saxon.function.XPathFunctionContext;
 import de.betterform.xml.xpath.impl.saxon.SaxonReferenceFinderImpl;
-import junit.framework.TestCase;
-
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * Tests reference detection.
@@ -65,6 +67,13 @@ public class XPathReferenceFinderTest extends TestCase {
 
     }
 
+    public void testGetReferencesWithNamespaces() throws Exception {
+    	Map prefixes = new HashMap();
+    	prefixes.put("ns", "http://example.com");
+       
+    	assertReferences(new String[]{"child::ns:data"},
+                this.referenceFinder.getReferences("ns:data", prefixes, fDummyContainer));
+    }
     /**
      * Tests reference detection for expressions with instance() function.
      *


### PR DESCRIPTION
When XPath Expressions in "relevant" attributes had prefixes in them, those prefixes were lost when analyzing the expressions and thus the expressions were never re-evaluated because betterFORM didn't recognize relevant changes in the data model.

This adds a test case demonstrating the low-level issue and fixes it.
