### PR TITLE
Support System Property substitution in xml-config values

### DIFF
--- a/core/src/main/java/de/betterform/xml/config/DefaultConfig.java
+++ b/core/src/main/java/de/betterform/xml/config/DefaultConfig.java
@@ -14,6 +14,7 @@ import net.sf.saxon.dom.DocumentWrapper;
 import net.sf.saxon.dom.NodeWrapper;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.sxpath.IndependentContext;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -104,8 +105,9 @@ public class DefaultConfig extends Config {
 		for(int i = 0; i < nodeset.size(); ++i) {
 			Element element = (Element) XPathUtil.getAsNode(nodeset, i + 1);
 
-			map.put(element.getAttribute(nameAttribute), element
-					.getAttribute(valueAttribute));
+			String attributeValue = StrSubstitutor.replaceSystemProperties(element.getAttribute(valueAttribute));
+
+			map.put(element.getAttribute(nameAttribute), attributeValue);
 		}
 
 		return map;

--- a/core/src/test/java/de/betterform/xml/config/ConfigTest.java
+++ b/core/src/test/java/de/betterform/xml/config/ConfigTest.java
@@ -60,6 +60,19 @@ public class ConfigTest extends TestCase {
                 value.equals("de.betterform.connector.smtp.SMTPSubmissionHandler"));
     }
 
+	/**
+	 * Quick test to determine whether the system variable replacement (e.g. ${java.home}) works.
+	 *
+	 * @throws XFormsConfigException
+	 */
+	public void testSystemVariableReplacement() throws XFormsConfigException {
+		Config config = Config.getInstance(getClass().getResource("test-default.xml").getPath());
+
+		String value = config.getProperty("test.substitution.property", null);
+		assertNotNull("test.substitution.property is unknown", value);
+		assertTrue("test.substitution.property is wrong: " + value, value.endsWith("/nonexistingfile.txt") && !value.startsWith("${java.home}"));
+	}
+	
     /**
      * Tests the external configuration.
      *

--- a/core/src/test/resources/de/betterform/xml/config/test-default.xml
+++ b/core/src/test/resources/de/betterform/xml/config/test-default.xml
@@ -20,6 +20,8 @@
         <!-- WARNING: not ready for production use -->
         <property name="betterform.event-optimization-enabled" value="false" description="TBD: if event optimization is enabled, only events present within the current form will be processed"/>
 
+		<!-- We only care that the substition of ${java.home} works in this case -->
+		<property name="test.substitution.property" value="${java.home}/nonexistingfile.txt"/>
     </properties>
 
     <useragents>


### PR DESCRIPTION
In our current setting, it is required to reference the standard java keystore within betterFORM. The standard java keystore resides in JAVA_HOME, which cannot be configured as absolute path (as this heavily depends on the machine, e.g. on linux systems this might be /usr/java/latest, on Windows systems this might be C:\Program Files\Java, ....).

Apache Tomcat allows substitutions of System properties with the syntax ${propertyName}, e.g. ${java.home}.

There's already a method in StrSubstitutor that does exactly that. No additional dependencies needed.

Test case is included and "green" on my machine (the test ought to succeed on every testing environment that has the property java.home set).
