### PR TITLE
FIX: WebFactory failed to initialize on Windows

### DIFF
--- a/web/src/main/java/de/betterform/agent/web/WebFactory.java
+++ b/web/src/main/java/de/betterform/agent/web/WebFactory.java
@@ -221,7 +221,7 @@ public class WebFactory {
 
     public URI getXsltURI(String xsltPath, String xsltDefault) throws URISyntaxException {
         String resolvePath = getRealPath(xsltPath + xsltDefault, servletContext);
-        String pathToXSLDirectory = resolvePath.substring(0, resolvePath.lastIndexOf("/"));
+        String pathToXSLDirectory = resolvePath.substring(0, resolvePath.lastIndexOf(File.separator));
         return new File(pathToXSLDirectory).toURI().resolve(new URI(xsltDefault));
     }
 

--- a/web/src/test/java/de/betterform/agent/web/WebFactoryTest.java
+++ b/web/src/test/java/de/betterform/agent/web/WebFactoryTest.java
@@ -1,0 +1,25 @@
+package de.betterform.agent.web;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class WebFactoryTest {
+
+    @Test
+    public void testGetXsltURI() throws URISyntaxException {
+
+        WebFactory wf = new WebFactory();
+
+        URI uri = wf.getXsltURI("/some/path/", "file.xsl");
+
+        assertThat(uri.getScheme(), is("file"));
+        assertTrue(uri.toString().endsWith("/web/some/file.xsl"));
+
+    }
+
+}


### PR DESCRIPTION
This is a trivial fix for a problem starting betterFORM on Windows. 

I ran into the problem because the current development eXist failed to start on a Windows system.

The unit test demonstrates the problem, but only when executed on a Windows machine: The resolvePath is platform-specific, so it may contain backslashes instead of slashes as path separators, leading to an StringIndexOutOfBoundsException in the unpatched version.
