### PR TITLE
More robust error logging in ErrorServlet

### DIFF
--- a/web/src/main/java/de/betterform/agent/web/servlet/ErrorServlet.java
+++ b/web/src/main/java/de/betterform/agent/web/servlet/ErrorServlet.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,11 +95,29 @@ public class ErrorServlet extends HttpServlet {
                 String linenumber = (String) n.getUserData("lineNumber");
                 DOMUtil.appendElement(rootNode, "lineNumber", linenumber);
 
-                DOMUtil.prettyPrintDOM(rootNode);
-
                 WebUtil.doTransform(getServletContext(), response, newDoc, "highlightError.xsl", rootNode);
+
             } catch (Exception e) {
-                e.printStackTrace();  
+
+                LOGGER.error(e);
+
+            } finally {
+
+                // in all cases, log whatever information about the error is available
+
+                try {
+
+                    if (LOGGER.isErrorEnabled()) {
+                        ByteArrayOutputStream messageBuf = new ByteArrayOutputStream();
+                        DOMUtil.prettyPrintDOM(rootNode, messageBuf);
+                        LOGGER.error(messageBuf.toString());
+                    }
+
+                } catch (Exception e) {
+                    // last resort
+                    LOGGER.error(msg, e);
+                }
+
             }
 
         } else{


### PR DESCRIPTION
There were several cases where internal processing in the ErrorServlet would throw an exception, resulting in the overly broad (and often wrong) message „XFormsException: Prefix xf has not been declared“ in the log.

This patch logs whatever information has been collected up to the point of the exception, resulting in much more helpful messages. It also uses LOGGER to output the error document instead of dumping it to System.out .
