### PR TITLE
Make sure that resourceUrl is correctly resolved when locating betterform-config.xml

### DIFF
--- a/core/build.number
+++ b/core/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Mon Aug 17 17:12:56 CEST 2015
-build.number=12286
+#Wed Jun 15 20:32:52 BST 2016
+build.number=12290

--- a/core/src/main/resources/META-INF/version.info
+++ b/core/src/main/resources/META-INF/version.info
@@ -1,1 +1,1 @@
-betterFORM 5.1-Snapshot - buildNumber:12285 - Timestamp:2015-08-17 17:12:56
+betterFORM 5.1-Snapshot - buildNumber:12289 - Timestamp:2016-06-15 20:32:52

--- a/web/src/main/java/de/betterform/agent/web/WebFactory.java
+++ b/web/src/main/java/de/betterform/agent/web/WebFactory.java
@@ -308,7 +308,7 @@ public class WebFactory {
                 String rootPath = new File(resourcePath).getParentFile().getParent();
                 computedRealPath = new File(rootPath, path).getAbsolutePath();
             } else if(resourceURL != null){
-                computedRealPath = new File(resourceURL.toExternalForm(),path).getAbsolutePath();
+                computedRealPath = new File(resourceURL.toURI()).getAbsolutePath();
             } else {
                 String resourcePath = context.getRealPath("/");
                 computedRealPath = new File(resourcePath, path).getAbsolutePath();


### PR DESCRIPTION
This looks like a simple code bug in a path that was most likely never exercised in the path.
This bug unveiled itself when running betterForm inside Jetty 9.3.9 .
